### PR TITLE
Add link to toolbelt.heroku.com

### DIFF
--- a/outline/setup_osx.md
+++ b/outline/setup_osx.md
@@ -76,6 +76,8 @@ After all that, you should be at your Heroku dashboard. There will be a link on 
 
 ![Heroku dashboard](img/heroku-dashboard.png)
 
+If you do not see this link on your dashboard, you can download the toolbelt from [toolbelt.heroku.com](https://toolbelt.heroku.com/).
+
 This will download a .pkg file. Click it to install the Heroku Toolbelt and follow all prompts from the installation wizard. You will need your password to complete installation. Once installation, go to your terminal and run the command `heroku login`. You will be prompted for your email and password on Heroku. If you enter them and the command ends successfully, congratulations!
 
 ![Heroku login](img/os_x/heroku_login.png)


### PR DESCRIPTION
If you already have a Heroku account, this link doesn't appear on the dashboard.
