### PR TITLE
Replace "LightTable" with "Light Table"

### DIFF
--- a/outline/intro.md
+++ b/outline/intro.md
@@ -56,11 +56,11 @@ How about the last line? That has a thing called a string in it, which we'll lea
 
 REPL stands for Read-Eval-Print-Loop, which still doesn't make a ton of sense without context. Many programming languages, including Clojure, have a way to execute code interactively so you get instant feedback. In other words, the code is read, then it is evaluated, then the result is printed, and you begin again, thus, a loop.
 
-Clojure has a REPL that you can run from the terminal easily, and we'll touch on that more later, but for now, let's use LightTable's "insta-REPL," a nice way to interact from within LightTable.
+Clojure has a REPL that you can run from the terminal easily, and we'll touch on that more later, but for now, let's use Light Table's "insta-REPL," a nice way to interact from within Light Table.
 
-Go ahead and start LightTable if you haven't already. Once it's started, go to the View menu and click "Commands." Notice that you can get to the command by typing ctrl+space from now on, if that's faster for you. Type "insta" and press enter when the "Instarepl: Open a Clojure instarepl" choice is highlighted.
+Go ahead and start Light Table if you haven't already. Once it's started, go to the View menu and click "Commands." Notice that you can get to the command by typing ctrl+space from now on, if that's faster for you. Type "insta" and press enter when the "Instarepl: Open a Clojure instarepl" choice is highlighted.
 
-After you hit enter, a blank new page will open. At the bottom of LightTable, you should see a message about connecting. Wait for the instarepl to finish connecting before typing anything. Once that's done, let's try out the REPL together! Type `(+ 2 3)` and see what happens. Did you see the result appearing beside what you were typing? Once you'd done that, hit enter and type `(max 8 17 2)`. You might see an error in red while typing. This happens because LightTable is continually evaluating what you are typing, and before you finish, the code might not be valid.
+After you hit enter, a blank new page will open. At the bottom of Light Table, you should see a message about connecting. Wait for the instarepl to finish connecting before typing anything. Once that's done, let's try out the REPL together! Type `(+ 2 3)` and see what happens. Did you see the result appearing beside what you were typing? Once you'd done that, hit enter and type `(max 8 17 2)`. You might see an error in red while typing. This happens because Light Table is continually evaluating what you are typing, and before you finish, the code might not be valid.
 
 ## Simple values
 

--- a/outline/setup.md
+++ b/outline/setup.md
@@ -13,7 +13,7 @@ By the end of these instructions, you will have the following installed:
 
 * Java, a "virtual machine" that Clojure runs atop of
 * Leiningen, a tool for running Clojure programs
-* LightTable, an editor for Clojure and other programming languages
+* Light Table, an editor for Clojure and other programming languages
 * The Heroku Toolbelt, a program for putting your Clojure application on the web
 * Git, a program for managing your program's code, which is included in the Heroku Toolbelt
 

--- a/outline/setup_osx.md
+++ b/outline/setup_osx.md
@@ -4,7 +4,7 @@ OS X Setup
 * Start a terminal
 * Make sure Java is installed
 * Get Leiningen installed
-* Get LightTable installed
+* Get Light Table installed
 * Get Heroku installed (includes Git)
 * Test installation
 
@@ -48,11 +48,11 @@ sudo chmod a+x /usr/local/bin/lein
 
 After you run the above commands, run the `lein` command. It should take a while to run, as it will download some resources it needs the first time. If it completes succesfully, you are golden! If not, ask an instructor for help.
 
-## Installing LightTable
+## Installing Light Table
 
-Go to the [LightTable site](http://www.lighttable.com/). On the page there, you should see a set of buttons that have download links for LightTable. Click the "OS X 10.7+" button and you will download a .zip file.
+Go to the [Light Table site](http://www.lighttable.com/). On the page there, you should see a set of buttons that have download links for Light Table. Click the "OS X 10.7+" button and you will download a .zip file.
 
-![LightTable downloads](img/os_x/light-table-download.png)
+![Light Table downloads](img/os_x/light-table-download.png)
 
 Unzip the downloaded file. It should be in your Downloads folder and be named LightTableMac.zip. Once unzipped, move LightTable.app to your Applications folder.
 
@@ -82,7 +82,7 @@ This will download a .pkg file. Click it to install the Heroku Toolbelt and foll
 
 ## Testing your setup
 
-You have set up Java, Leiningen, LightTable, Git, and Heroku on your computer, all the tools you will need for this program. Before starting, we need to test them out.
+You have set up Java, Leiningen, Light Table, Git, and Heroku on your computer, all the tools you will need for this program. Before starting, we need to test them out.
 
 Go to your terminal and run the following command:
 
@@ -106,15 +106,15 @@ This could take a long time, and will download many other pieces of code it reli
 
 This is starting a REPL, which we will learn about soon. It's a special terminal for Clojure. At the REPL prompt, type `(+ 1 1)` and press Return. Did you get the answer `2` back? You will learn more about that in the course. For now, press the Control button and D button on your keyboard together (abbreviated as Ctrl+D). This should take you out of the Clojure REPL and back to your normal terminal prompt.
 
-Now, start LightTable. Once it is started, press the Control button and Space Bar together (abbreviated Ctrl+Space). This is how you start giving Light Table a command. Start typing the word "instarepl" and you should see a menu of options, like below. Choose "Instarepl: open a clojure instarepl."
+Now, start Light Table. Once it is started, press the Control button and Space Bar together (abbreviated Ctrl+Space). This is how you start giving Light Table a command. Start typing the word "instarepl" and you should see a menu of options, like below. Choose "Instarepl: open a clojure instarepl."
 
-![Testing LightTable - starting instarepl](img/os_x/testing-step3.png)
+![Testing Light Table - starting instarepl](img/os_x/testing-step3.png)
 
 At the bottom of the screen, you will see a cube moving and some text about connecting and installing dependencies. Once that stops moving, type `(+ 1 1)` into the window. It should look like the following image:
 
-![Testing LightTable - running in the instarepl](img/os_x/testing-step4.png)
+![Testing Light Table - running in the instarepl](img/os_x/testing-step4.png)
 
-If that worked, great! Close LightTable. We only have one more thing to test, Heroku.
+If that worked, great! Close Light Table. We only have one more thing to test, Heroku.
 
 Go back to your terminal. You should still be in the `clojure-sample` directory.
 

--- a/outline/setup_win7.md
+++ b/outline/setup_win7.md
@@ -4,7 +4,7 @@ Windows 7 Setup
 * Start a command prompt
 * Get Java installed
 * Get Leiningen installed
-* Get LightTable installed
+* Get Light Table installed
 * Get Heroku installed (includes Git)
 * Test installation
 
@@ -48,15 +48,15 @@ Leiningen is a tool used on the command line to manage Clojure projects.
 
 Next, go back to [the Leiningen Windows installer site](http://leiningen-win-installer.djpowell.net/) and download the file linked as "leiningen-win-installer." Run this executable and follow the "Detailed installation" section at the Leiningen Windows Installer site. At the end of the installation, leave "Run a Clojure REPL" checked before you click "Finish." If a terminal window opens that looks like the one on the Leiningen Windows installer site, then you are good to go.
 
-## Installing LightTable
+## Installing Light Table
 
-Go to the [LightTable site](http://www.lighttable.com/). On the page there, you should see a set of buttons that have download links for LightTable. Click the "Win" button and you will download a .zip file.
+Go to the [Light Table site](http://www.lighttable.com/). On the page there, you should see a set of buttons that have download links for Light Table. Click the "Win" button and you will download a .zip file.
 
-![LightTable downloads](img/win/light-table-download.png)
+![Light Table downloads](img/win/light-table-download.png)
 
-Unzip this file (either by finding it in your Downloads folder and double-clicking it, or by choosing "Open" when downloading.) Inside the .zip file, there is a a directory called "LightTable". Drag this to your desktop. (If you know what you are doing and want this somewhere else, that is fine.)
+Unzip this file (either by finding it in your Downloads folder and double-clicking it, or by choosing "Open" when downloading.) Inside the .zip file, there is a a directory called "Light Table". Drag this to your desktop. (If you know what you are doing and want this somewhere else, that is fine.)
 
-Inside the LightTable directory, there is an application called LightTable. Right-click it and choose "Pin to Start Menu" so you can start it more quickly.
+Inside the Light Table directory, there is an application called Light Table. Right-click it and choose "Pin to Start Menu" so you can start it more quickly.
 
 ## Get setup with Heroku
 
@@ -97,7 +97,7 @@ After that, run the command `heroku login`. You will be prompted for your email 
 
 ## Testing your setup
 
-You have set up Java, Leiningen, LightTable, Git, and Heroku on your computer, all the tools you will need for this program. Before starting, we need to test them out. Make sure you have a terminal (OS X) or command prompt (Windows) open for testing. We will just call this a terminal from now on.
+You have set up Java, Leiningen, Light Table, Git, and Heroku on your computer, all the tools you will need for this program. Before starting, we need to test them out. Make sure you have a terminal (OS X) or command prompt (Windows) open for testing. We will just call this a terminal from now on.
 
 Go to your terminal and run the following command:
 
@@ -121,15 +121,15 @@ This could take a long time, and will download many other pieces of code it reli
 
 This is starting a REPL, which we will learn about soon. It's a special terminal for Clojure. At the REPL prompt, type `(+ 1 1)` and hit enter. Did you get the answer `2` back? You will learn more about that in the course. For now, press the Control button and D button on your keyboard together (abbreviated as Ctrl+D). This should take you out of the Clojure REPL and back to your normal terminal prompt.
 
-Now, start LightTable. Once it is started, press the Control button and Space Bar together (abbreviated Ctrl+Space). This is how you start giving Light Table a command. Start typing the word "instarepl" and you should see a menu of options, like below. Choose "Instarepl: open a clojure instarepl."
+Now, start Light Table. Once it is started, press the Control button and Space Bar together (abbreviated Ctrl+Space). This is how you start giving Light Table a command. Start typing the word "instarepl" and you should see a menu of options, like below. Choose "Instarepl: open a clojure instarepl."
 
-![Testing LightTable - starting instarepl](img/win7/testing-step3.png)
+![Testing Light Table - starting instarepl](img/win7/testing-step3.png)
 
 At the bottom of the screen, you will see a cube moving and some text about connecting and installing dependencies. Once that stops moving, type `(+ 1 1)` into the window. It should look like the following image:
 
-![Testing LightTable - running in the instarepl](img/win7/testing-step4.png)
+![Testing Light Table - running in the instarepl](img/win7/testing-step4.png)
 
-If that worked, great! Close LightTable. We only have one more thing to test, Heroku.
+If that worked, great! Close Light Table. We only have one more thing to test, Heroku.
 
 Go back to your terminal. You should still be in the `clojure-sample` directory.
 

--- a/outline/setup_win8.md
+++ b/outline/setup_win8.md
@@ -4,7 +4,7 @@ Windows 8 Setup
 * Start a command prompt
 * Get Java installed
 * Get Leiningen installed
-* Get LightTable installed
+* Get Light Table installed
 * Get Heroku installed (includes Git)
 * Test installation
 
@@ -48,15 +48,15 @@ Leiningen is a tool used on the command line to manage Clojure projects.
 
 Next, go back to [the Leiningen Windows installer site](http://leiningen-win-installer.djpowell.net/) and download the file linked as "leiningen-win-installer." Run this executable and follow the "Detailed installation" section at the Leiningen Windows Installer site. At the end of the installation, leave "Run a Clojure REPL" checked before you click "Finish." If a terminal window opens that looks like the one on the Leiningen Windows installer site, then you are good to go.
 
-## Installing LightTable
+## Installing Light Table
 
-Go to the [LightTable site](http://www.lighttable.com/). On the page there, you should see a set of buttons that have download links for LightTable. Click the "Win" button and you will download a .zip file.
+Go to the [Light Table site](http://www.lighttable.com/). On the page there, you should see a set of buttons that have download links for Light Table. Click the "Win" button and you will download a .zip file.
 
-![LightTable downloads](img/win/light-table-download.png)
+![Light Table downloads](img/win/light-table-download.png)
 
-Unzip this file (either by finding it in your Downloads folder and double-clicking it, or by choosing "Open" when downloading.) Inside the .zip file, there is a a directory called "LightTable". Drag this to your desktop. (If you know what you are doing and want this somewhere else, that is fine.)
+Unzip this file (either by finding it in your Downloads folder and double-clicking it, or by choosing "Open" when downloading.) Inside the .zip file, there is a a directory called "Light Table". Drag this to your desktop. (If you know what you are doing and want this somewhere else, that is fine.)
 
-Inside the LightTable directory, there is an application called LightTable. Right-click it and choose "Pin to Start Menu" so you can start it more quickly.
+Inside the Light Table directory, there is an application called Light Table. Right-click it and choose "Pin to Start Menu" so you can start it more quickly.
 
 ## Get setup with Heroku
 
@@ -97,7 +97,7 @@ After that, run the command `heroku login`. You will be prompted for your email 
 
 ## Testing your setup
 
-You have set up Java, Leiningen, LightTable, Git, and Heroku on your computer, all the tools you will need for this program. Before starting, we need to test them out. Make sure you have a terminal (OS X) or command prompt (Windows) open for testing. We will just call this a terminal from now on.
+You have set up Java, Leiningen, Light Table, Git, and Heroku on your computer, all the tools you will need for this program. Before starting, we need to test them out. Make sure you have a terminal (OS X) or command prompt (Windows) open for testing. We will just call this a terminal from now on.
 
 Go to your terminal and run the following command:
 
@@ -121,15 +121,15 @@ This could take a long time, and will download many other pieces of code it reli
 
 This is starting a REPL, which we will learn about soon. It's a special terminal for Clojure. At the REPL prompt, type `(+ 1 1)` and hit enter. Did you get the answer `2` back? You will learn more about that in the course. For now, press the Control button and D button on your keyboard together (abbreviated as Ctrl+D). This should take you out of the Clojure REPL and back to your normal terminal prompt.
 
-Now, start LightTable. Once it is started, press the Control button and Space Bar together (abbreviated Ctrl+Space). This is how you start giving Light Table a command. Start typing the word "instarepl" and you should see a menu of options, like below. Choose "Instarepl: open a clojure instarepl."
+Now, start Light Table. Once it is started, press the Control button and Space Bar together (abbreviated Ctrl+Space). This is how you start giving Light Table a command. Start typing the word "instarepl" and you should see a menu of options, like below. Choose "Instarepl: open a clojure instarepl."
 
-![Testing LightTable - starting instarepl](img/win7/testing-step3.png)
+![Testing Light Table - starting instarepl](img/win7/testing-step3.png)
 
 At the bottom of the screen, you will see a cube moving and some text about connecting and installing dependencies. Once that stops moving, type `(+ 1 1)` into the window. It should look like the following image:
 
-![Testing LightTable - running in the instarepl](img/win7/testing-step4.png)
+![Testing Light Table - running in the instarepl](img/win7/testing-step4.png)
 
-If that worked, great! Close LightTable. We only have one more thing to test, Heroku.
+If that worked, great! Close Light Table. We only have one more thing to test, Heroku.
 
 Go back to your terminal. You should still be in the `clojure-sample` directory.
 


### PR DESCRIPTION
Based on http://www.lighttable.com/, it looks like "Light Table" with a space is the proper branding.
