### PR TITLE
addendum to ssh-keygen command for 64-bit Win 7 users

### DIFF
--- a/outline/setup_win7.md
+++ b/outline/setup_win7.md
@@ -82,12 +82,22 @@ You will download an .exe file. Run this executable to install the Heroku Toolbe
 
 Before you can use Heroku, you will have to set up SSH, the way your computer communicates with Heroku.
 
-First, look up what your user directory is. You can find it by running `echo %USERPROFILE%`. Then, run these commands:
+First, look up what your user directory is. You can find it by running `echo %USERPROFILE%`. Create a place for your SSH keys by running this command:
 
 ```
 mkdir %USERPROFILE%\.ssh
+```
 
+Then, if you have 32-bit Windows, run this command:
+
+```
 "C:\Program Files\Git\bin\ssh-keygen.exe"
+```
+
+If you have 64-bit Windows, run this command instead:
+
+```
+"C:\Program Files (x86)\Git\bin\ssh-keygen.exe"
 ```
 
 The quotes are necessary on the `ssh-keygen.exe` command. When you run `ssh-keygen.exe`, you will need to type the name of your user directory - everything from "C:\" onward - plus `\.ssh\id_rsa` when it asks you where to save the key. Be careful to type everything exactly. When it asks to 'Enter passphrase' just hit Enter, then Enter again. *Look at the following example:*


### PR DESCRIPTION
When I worked through the install instructions for Win7, ssh-keygen failed. This should keep others from hitting the same problem.
