### PR TITLE
Modified installation instructions for OS X

### DIFF
--- a/outline/setup_osx.md
+++ b/outline/setup_osx.md
@@ -3,9 +3,10 @@ OS X Setup
 
 * Start a terminal
 * Install Git
+* Configure Git
 * Make sure Java is installed
 * Get Leiningen installed
-* Get Light Table installed
+* Get LightTable installed
 * Get Heroku installed
 * Test installation
 


### PR DESCRIPTION
Light Table > LightTable (although I see now that on the website it's Light Table: http://www.lighttable.com/, on github it's LightTable: https://github.com/LightTable/LightTable) Ignore?

Git Config instructions from RailsBridge Installfest (Is there a minimum git --version?)

Heroku, has a new Dashboard, (and couldn't find toolbelt in UI), so removed "found under the Dashboard", but left in Heroku Toolbelt link.
