### PR TITLE
Add git config instructions for Ubuntu and Windows

### DIFF
--- a/outline/setup_osx.md
+++ b/outline/setup_osx.md
@@ -30,8 +30,9 @@ If not, visit [git-scm.com](http://git-scm.com/). Click "Downloads for Mac". The
 
 ## Configure Git
 
-If you've used Git then you should already have user.name and user.email configured.
-Type this in the terminal:
+If you've used Git before then you should already have user.name and user.email configured.
+Otherwise, type this in the terminal:
+
 ```
 git config --global user.name "Your Actual Name"
 git config --global user.email "Your Actual Email"

--- a/outline/setup_ubuntu.md
+++ b/outline/setup_ubuntu.md
@@ -107,6 +107,27 @@ If you do not see this link on your dashboard, you can download the toolbelt fro
 
 This will take you too a page with a terminal command. Copy this command and paste it into your terminal. Once the Heroku Toolbelt is installed, run the command `heroku login`. You will be prompted for your email and password on Heroku. If you are prompted to create an SSH key, say yes. If you enter them and the command ends successfully, congratulations!
 
+## Configuring Git
+
+If you've used Git before then you should already have user.name and user.email configured.
+Otherwise, type this in the terminal:
+
+```
+git config --global user.name "Your Actual Name"
+git config --global user.email "Your Actual Email"
+```
+TIP: Use the same email address for heroku, git, github, and ssh.
+
+Verify by typing this in the terminal:
+
+`git config --get user.name`
+Expected result:
+`your name`
+
+`git config --get user.email`
+Expected result:
+`your email address`
+
 ## Testing your setup
 
 You have set up Java, Leiningen, Light Table, Git, and Heroku on your computer--all the tools you will need for this course. Before starting, we need to test them out.

--- a/outline/setup_win7.md
+++ b/outline/setup_win7.md
@@ -106,6 +106,27 @@ The quotes are necessary on the `ssh-keygen.exe` command. When you run `ssh-keyg
 
 After that, close the command prompt, open it again, and run the command `heroku login`. You will be prompted for your email and password on Heroku. If you enter them and the command ends successfully, congratulations!
 
+## Configure Git
+
+If you've used Git before then you should already have user.name and user.email configured.
+Otherwise, type this in the command prompt:
+
+```
+git config --global user.name "Your Actual Name"
+git config --global user.email "Your Actual Email"
+```
+TIP: Use the same email address for heroku, git, github, and ssh.
+
+Verify by typing this in the command prompt:
+
+`git config --get user.name`
+Expected result:
+`your name`
+
+`git config --get user.email`
+Expected result:
+`your email address`
+
 ## Testing your setup
 
 You have set up Java, Leiningen, Light Table, Git, and Heroku on your computer, all the tools you will need for this program. Before starting, we need to test them out. Make sure you have a terminal (OS X) or command prompt (Windows) open for testing. We will just call this a terminal from now on.

--- a/outline/setup_win8.md
+++ b/outline/setup_win8.md
@@ -96,6 +96,27 @@ The quotes are necessary on the `ssh-keygen.exe` command. When you run `ssh-keyg
 
 After that, close the command prompt, open it back up, and run the command `heroku login`. You will be prompted for your email and password on Heroku. If you enter them and the command ends successfully, congratulations!
 
+## Configure Git
+
+If you've used Git before then you should already have user.name and user.email configured.
+Otherwise, type this in the command prompt:
+
+```
+git config --global user.name "Your Actual Name"
+git config --global user.email "Your Actual Email"
+```
+TIP: Use the same email address for heroku, git, github, and ssh.
+
+Verify by typing this in the command prompt:
+
+`git config --get user.name`
+Expected result:
+`your name`
+
+`git config --get user.email`
+Expected result:
+`your email address`
+
 ## Testing your setup
 
 You have set up Java, Leiningen, Light Table, Git, and Heroku on your computer, all the tools you will need for this program. Before starting, we need to test them out. Make sure you have a terminal (OS X) or command prompt (Windows) open for testing. We will just call this a terminal from now on.


### PR DESCRIPTION
Copied the "Configuring Git" from OS X setup instructions to Ubuntu and Windows (changing "terminal" to "command prompt").

Deploying to Heroku requires making a git commit, and `git commit` will complain if user.name and user.email are not set. And since there are instructions to set up ssh keys it probably makes sense to do this at this stage.
