### PR TITLE
slides: remove y-axis navigation

### DIFF
--- a/slides/assets/reveal.js/css/reveal.css
+++ b/slides/assets/reveal.js/css/reveal.css
@@ -1878,3 +1878,11 @@ body {
 }
 
 
+/*********************************************
+ * HIDE UP AND DOWN NAVIGATION ELEMENTS
+ *********************************************/
+
+.navigate-up,
+.navigate-down {
+	visibility: hidden;
+}

--- a/slides/module1.html
+++ b/slides/module1.html
@@ -20,7 +20,6 @@
         <h1 class="slide-title intro">Module 1</h1>
       </section>
 
-      <section>
         <section>
           <h2 class="slide-title chapter">Introduction to
           Programming with Clojure</h2>
@@ -90,9 +89,7 @@
             "img/instarepl.png"></div>
           </div>
         </section>
-      </section>
 
-      <section>
         <section>
           <h2 class="slide-title chapter">Simple values</h2>
         </section>
@@ -193,9 +190,7 @@
 false</code>
 </pre>
         </section>
-      </section>
 
-      <section>
         <section>
           <h2 class="slide-title chapter">Assigning names to
           values</h2>
@@ -239,7 +234,6 @@ false</code>
             </li>
           </ul>
         </section>
-      </section>
     </div>
   </div><script src="assets/reveal.js/lib/js/head.min.js">
 </script> <script src="assets/reveal.js/js/reveal.js">

--- a/slides/module2.html
+++ b/slides/module2.html
@@ -20,7 +20,6 @@
         <h1 class="slide-title intro">Module 2</h1>
       </section>
 
-      <section>
         <section>
           <h2 class="slide-title chapter">Data Structures</h2>
         </section>
@@ -92,7 +91,6 @@
           <code>nth</code> function to get the high temperature for
           next Tuesday.</p>
         </section>
-      </section>
     </div>
   </div><script src="assets/reveal.js/lib/js/head.min.js">
 </script> <script src="assets/reveal.js/js/reveal.js">

--- a/slides/module3.html
+++ b/slides/module3.html
@@ -20,7 +20,6 @@
         <h1 class="slide-title intro">Module 3</h1>
       </section>
 
-      <section>
         <section>
           <h2 class="slide-title chapter">Functions</h2>
         </section>
@@ -117,9 +116,7 @@
             </li>
           </ul>
         </section>
-      </section>
 
-      <section>
         <section>
           <h2 class="slide-title chapter">Functions that take other
           functions</h2>
@@ -181,7 +178,6 @@
           <p>Hint: you will need to use <code>reduce</code> and
           <code>count</code>.</p>
         </section>
-      </section>
     </div>
   </div><script src="assets/reveal.js/lib/js/head.min.js">
 </script> <script src="assets/reveal.js/js/reveal.js">

--- a/slides/module4.html
+++ b/slides/module4.html
@@ -20,7 +20,6 @@
         <h1 class="slide-title intro">Module 4</h1>
       </section>
 
-      <section>
         <section>
           <h2 class="slide-title chapter">Strings, Keywords, and
           Booleans</h2>
@@ -84,7 +83,6 @@ false</code>
           <code>last-name</code>. This function should output the
           name like so: Last, First.</p>
         </section>
-      </section>
     </div>
   </div><script src="assets/reveal.js/lib/js/head.min.js">
 </script> <script src="assets/reveal.js/js/reveal.js">

--- a/slides/module5.html
+++ b/slides/module5.html
@@ -20,7 +20,6 @@
         <h1 class="slide-title intro">Module 5</h1>
       </section>
 
-      <section>
         <section>
           <h2 class="slide-title chapter">Common, core
           functions</h2>
@@ -99,7 +98,6 @@
   ;=&gt; "i like peanut butter and jelly"</code>
 </pre>
         </section>
-      </section>
     </div>
   </div><script src="assets/reveal.js/lib/js/head.min.js">
 </script> <script src="assets/reveal.js/js/reveal.js">

--- a/slides/module6.html
+++ b/slides/module6.html
@@ -20,7 +20,6 @@
         <h1 class="slide-title intro">Module 6</h1>
       </section>
 
-      <section>
         <section>
           <h2 class="slide-title chapter">More Data Structures</h2>
         </section>
@@ -167,7 +166,6 @@
             using <code>conj</code>.</li>
           </ol>
         </section>
-      </section>
     </div>
   </div><script src="assets/reveal.js/lib/js/head.min.js">
 </script> <script src="assets/reveal.js/js/reveal.js">

--- a/slides/module7.html
+++ b/slides/module7.html
@@ -20,7 +20,6 @@
         <h1 class="slide-title intro">Module 7</h1>
       </section>
 
-      <section>
         <section>
           <h2 class="slide-title chapter">Flow control</h2>
         </section>
@@ -118,9 +117,7 @@
           "Last, First Middle"; otherwise, it should be "First
           Middle Last."</p>
         </section>
-      </section>
 
-      <section>
         <section>
           <h2 class="slide-title chapter">Boolean logic</h2>
         </section>
@@ -201,9 +198,7 @@
             </tr>
           </table>
         </section>
-      </section>
 
-      <section>
         <section>
           <h2 class="slide-title chapter">Let</h2>
         </section>
@@ -276,7 +271,6 @@
           <p>Part three: rewrite the nested if statements using the
           <code>cond</code> function.</p>
         </section>
-      </section>
     </div>
   </div><script src="assets/reveal.js/lib/js/head.min.js">
 </script> <script src="assets/reveal.js/js/reveal.js">

--- a/slides/module8.html
+++ b/slides/module8.html
@@ -20,7 +20,6 @@
         <h1 class="slide-title intro">Module 8</h1>
       </section>
 
-      <section>
         <section>
           <h2 class="slide-title chapter">Projects</h2>
         </section>
@@ -98,9 +97,7 @@
 lein run</code>
 </pre>
         </section>
-      </section>
 
-      <section>
         <section>
           <h2 class="slide-title chapter">Modifying a project</h2>
         </section>
@@ -180,9 +177,7 @@ lein run</code>
             [cheshire.core :as json]))</code>
 </pre>
         </section>
-      </section>
 
-      <section>
         <section>
           <h2 class="slide-title chapter">Your first real
           program</h2>
@@ -392,9 +387,7 @@ lein run</code>
 
           <p>What do you get?</p>
         </section>
-      </section>
 
-      <section>
         <section>
           <h2 class="slide-title chapter">Revisiting -main</h2>
         </section>
@@ -447,7 +440,6 @@ lein run</code>
           You will need the <code>sort-by</code> function to make
           this work.</p>
         </section>
-      </section>
     </div>
   </div><script src="assets/reveal.js/lib/js/head.min.js">
 </script> <script src="assets/reveal.js/js/reveal.js">

--- a/slides/module9.html
+++ b/slides/module9.html
@@ -20,7 +20,6 @@
         <h1 class="slide-title intro">Module 9</h1>
       </section>
 
-      <section>
         <section>
           <h2 class="slide-title chapter">Web Applications</h2>
         </section>
@@ -57,9 +56,7 @@
           <p>Go to clojurebridge.org in your web browser and view
           the source.</p>
         </section>
-      </section>
 
-      <section>
         <section>
           <h2 class="slide-title chapter">Clojure web
           applications</h2>
@@ -167,7 +164,6 @@ Started server on port 3000</code>
 
           <p>Go to http://localhost:3000/.</p>
         </section>
-      </section>
     </div>
   </div><script src="assets/reveal.js/lib/js/head.min.js">
 </script> <script src="assets/reveal.js/js/reveal.js">


### PR DESCRIPTION
This makes the slides much easier to navigate: the slides exist on one axis to be viewed from left to right.

I'm not sure whether I've updated the right files, nor do I know whether this pull request should be against `master` or `gh-pages`. I don't see a makefile so I don't know whether there's a build step (and if there is, I don't know which commands to run). Let me know if I've missed a step so I can make amends. :)
