### PR TITLE
slides: remove significant trailing whitespace in code blocks

### DIFF
--- a/slides/module1.html
+++ b/slides/module1.html
@@ -57,8 +57,7 @@
           <pre>
 <code>(+ 3 4)
 (max 8 17 2)
-(eat "sandwich")</code>
-</pre>
+(eat "sandwich")</code></pre>
         </section>
 
         <section>
@@ -66,8 +65,7 @@
           <pre>
 <code>;; more food code
 (eat "cookie") ; nom nom nom
-(eat "donut") ; mmm donuts</code>
-</pre>
+(eat "donut") ; mmm donuts</code></pre>
         </section>
 
         <section>
@@ -124,8 +122,7 @@
 
 ;; ratios
 1/2
--7/3</code>
-</pre>
+-7/3</code></pre>
         </section>
 
         <section>
@@ -134,8 +131,7 @@
 <code>(+ 1 1)  ;=&gt; 1 + 1 = 2
 (- 12 4) ;=&gt; 12 - 4 = 8
 (* 13 2) ;=&gt; 13 * 2 = 26
-(/ 27 9) ;=&gt; 27 / 9 = 3</code>
-</pre>
+(/ 27 9) ;=&gt; 27 / 9 = 3</code></pre>
         </section>
 
         <section>
@@ -166,8 +162,7 @@
 <code>(+ 4/3 7/8)    ;=&gt; 53/24
 (- 9 4.2 1/2)  ;=&gt; 4.3
 (* 8 1/4)      ;=&gt; 2
-(/ 27/2 1.5)   ;=&gt; 3.0</code>
-</pre>
+(/ 27/2 1.5)   ;=&gt; 3.0</code></pre>
         </section>
 
         <section>
@@ -177,21 +172,18 @@
           <p>String examples</p>
           <pre>
 <code>"Salut tout le monde"
-"Prost!"</code>
-</pre>
+"Prost!"</code></pre>
 
           <p>Keyword examples</p>
           <pre>
 <code class="language-clojure">:surname
 :birth-date
-:r2</code>
-</pre>
+:r2</code></pre>
 
           <p>Boolean examples</p>
           <pre>
 <code class="language-clojure">true
-false</code>
-</pre>
+false</code></pre>
         </section>
       </section>
 
@@ -206,8 +198,7 @@ false</code>
           <pre>
 <code>(def mangoes 3)
 (def oranges 5)
-(+ mangoes oranges)</code>
-</pre>
+(+ mangoes oranges)</code></pre>
         </section>
 
         <section>

--- a/slides/module2.html
+++ b/slides/module2.html
@@ -51,8 +51,7 @@
           <pre>
 <code class="clojure">[1 2 3 4 5]
 [56.9 60.2 61.8 63.1 64.3 66.4 66.5 68.1 70.2 69.2 63.1 57.1]
-[]</code>
-</pre>
+[]</code></pre>
         </section>
 
         <section>
@@ -65,8 +64,7 @@
 ;;=&gt; [5 10 15]
 
 (conj [5 10] 15)
-;;=&gt; [5 10 15]</code>
-</pre>
+;;=&gt; [5 10 15]</code></pre>
         </section>
 
         <section>
@@ -79,8 +77,7 @@
 ;;=&gt; 10
 
 (first [5 10 15])
-;;=&gt; 5</code>
-</pre>
+;;=&gt; 5</code></pre>
         </section>
 
         <section>

--- a/slides/module3.html
+++ b/slides/module3.html
@@ -50,8 +50,7 @@
 
 (total-bill 8.5)  ;=&gt; 9.18
 (total-bill 50)   ;=&gt; 54.0
-(total-bill 50/6) ;=&gt; 9.0</code>
-</pre>
+(total-bill 50/6) ;=&gt; 9.0</code></pre>
         </section>
 
         <section>
@@ -67,8 +66,7 @@
   [x] ; list of arguments
 
   ;; body of function
-  (* 1.08 subtotal))</code>
-</pre>
+  (* 1.08 subtotal))</code></pre>
         </section>
 
         <section>
@@ -80,8 +78,7 @@
   [subtotal tip-pct] ;; takes 2 arguments
   (* 1.08 subtotal (+ 1 tip-pct)))
 
-(total-with-tip 12 0.18) ;=&gt; 15.93</code>
-</pre>
+(total-with-tip 12 0.18) ;=&gt; 15.93</code></pre>
         </section>
 
         <section>
@@ -134,8 +131,7 @@
 (map total-bill dine-in-orders)
   ;=&gt; [13.5 21.6 22.68 17.28 19.872]
 (map total-bill take-out-orders)
-  ;=&gt; [6.48 6.48 8.586 6.75]</code>
-</pre>
+  ;=&gt; [6.48 6.48 8.586 6.75]</code></pre>
         </section>
 
         <section>
@@ -145,8 +141,7 @@
   [x y]
   (+ x y))
 
-(reduce add [1 2 3]) ;=&gt; 6</code>
-</pre>
+(reduce add [1 2 3]) ;=&gt; 6</code></pre>
         </section>
 
         <section>
@@ -154,8 +149,7 @@
           <pre>
 <code class="clojure">(def take-out-totals [6.48 6.48 8.586 6.75])
 
-(reduce add take-out-totals) ;=&gt; 28.296</code>
-</pre>
+(reduce add take-out-totals) ;=&gt; 28.296</code></pre>
         </section>
 
         <section>
@@ -166,8 +160,7 @@
 
 (add 6.48    6.48)  ;=&gt; 12.96
 (add 12.96   8.586) ;=&gt; 21.546
-(add 21.546  6.75)  ;=&gt; 28.296</code>
-</pre>
+(add 21.546  6.75)  ;=&gt; 28.296</code></pre>
         </section>
 
         <section>

--- a/slides/module4.html
+++ b/slides/module4.html
@@ -31,8 +31,7 @@
           <pre>
 <code class="language-clojure">"Hello world"
 "This is a longer string that I wrote for purposes of an example."
-"Aubrey said, \"I think we should go to the Orange Julius.\""</code>
-</pre>
+"Aubrey said, \"I think we should go to the Orange Julius.\""</code></pre>
         </section>
 
         <section>
@@ -41,11 +40,9 @@
           <p>Answers to questions</p>
           <pre>
 <code class="language-clojure">true
-false</code>
-</pre>
+false</code></pre>
           <pre>
-<code class="language-clojure">nil</code>
-</pre>
+<code class="language-clojure">nil</code></pre>
         </section>
 
         <section>
@@ -58,8 +55,7 @@ false</code>
           used for labels.</p>
           <pre>
 <code class="language-clojure">:name
-:input</code>
-</pre>
+:input</code></pre>
         </section>
 
         <section>

--- a/slides/module5.html
+++ b/slides/module5.html
@@ -35,8 +35,7 @@
 (&lt; -1 1)   ;=&gt; true
 (&lt;= -1 -2) ;=&gt; false
 (&lt; 1 5 9)  ;=&gt; true
-(&lt; 1 5 3)  ;=&gt; false</code>
-</pre>
+(&lt; 1 5 3)  ;=&gt; false</code></pre>
         </section>
 
         <section>
@@ -45,8 +44,7 @@
           <pre>
 <code class="clojure">(defn meaning-of-life?
   [x]
-  (= x 42))</code>
-</pre>
+  (= x 42))</code></pre>
         </section>
 
         <section>
@@ -54,8 +52,7 @@
           <pre>
 <code class=
 "clojure">(str "Chocolate" ", " "strawberry" ", and " "vanilla")
-;;=&gt; "Chocolate, strawberry, and vanilla"</code>
-</pre>
+;;=&gt; "Chocolate, strawberry, and vanilla"</code></pre>
         </section>
 
         <section>
@@ -67,8 +64,7 @@
 
 (reduce join-with-space
         ["i" "like" "peanut" "butter" "and" "jelly"])
-;;=&gt; "i like peanut butter and jelly"</code>
-</pre>
+;;=&gt; "i like peanut butter and jelly"</code></pre>
         </section>
 
         <section>
@@ -82,8 +78,7 @@
 (join-with-space "i like" "peanut")
 (join-with-space "i like peanut" "butter")
 (join-with-space "i like peanut butter" "and")
-(join-with-space "i like peanut butter and" "jelly")</code>
-</pre>
+(join-with-space "i like peanut butter and" "jelly")</code></pre>
         </section>
 
         <section>
@@ -96,8 +91,7 @@
 (reduce
   (fn [s1 s2] (str s1 " " s2))
   ["i" "like" "peanut" "butter" "and" "jelly"])
-  ;=&gt; "i like peanut butter and jelly"</code>
-</pre>
+  ;=&gt; "i like peanut butter and jelly"</code></pre>
         </section>
       </section>
     </div>

--- a/slides/module6.html
+++ b/slides/module6.html
@@ -36,8 +36,7 @@
 <code class=
 "clojure">{:first "Sally", :last "Brown", :job "programmer"}
 {:a 1, :b "two"}
-{}</code>
-</pre>
+{}</code></pre>
 
           <ul>
             <li>Similar to comments, commas are ignored by
@@ -55,8 +54,7 @@
 ;;=&gt; "Sally"
 
 (get {:first "Sally"} :last :MISS)
-;;=&gt; :MISS</code>
-</pre>
+;;=&gt; :MISS</code></pre>
         </section>
 
         <section>
@@ -72,8 +70,7 @@
 ;;=&gt; {:first "Sally", :last "Brown"}
 
 (count {:first "Sally" :last "Brown"})
-;;=&gt; 2</code>
-</pre>
+;;=&gt; 2</code></pre>
         </section>
 
         <section>
@@ -84,8 +81,7 @@
 ;;=&gt; (:first :last)
 
 (vals {:first "Sally" :last "Brown"})
-;;=&gt; ("Sally" "Brown")</code>
-</pre>
+;;=&gt; ("Sally" "Brown")</code></pre>
         </section>
 
         <section>
@@ -98,8 +94,7 @@
 ;;=&gt; nil
 
 (:last {:first "Sally"} :MISS)
-;;=&gt; :MISS</code>
-</pre>
+;;=&gt; :MISS</code></pre>
         </section>
 
         <section>
@@ -121,8 +116,7 @@
  {:name "Earth" :moons ["The Moon"]}
  {:name "Mars" :moons ["Phobos" "Deimos"]}
  {:name "Jupiter"
-  :moons ["Ganymede" "Callisto" "Io" "Europa"]}]</code>
-</pre>
+  :moons ["Ganymede" "Callisto" "Io" "Europa"]}]</code></pre>
         </section>
 
         <section>
@@ -142,8 +136,7 @@
             {:first "Alice" :last "Munro"}])
 
 ;;=&gt; ["Margaret Atwood" "Doris Lessing"
-;;    "Ursula Le Guin" "Alice Munro"]</code>
-</pre>
+;;    "Ursula Le Guin" "Alice Munro"]</code></pre>
 
           <div style="text-align: left">
             Hint: First, create a function that returns the name

--- a/slides/module7.html
+++ b/slides/module7.html
@@ -34,8 +34,7 @@
           <pre>
 <code class="clojure">(if (valid? data)
   (save! data)
-  (error "Your data was invalid"))</code>
-</pre>
+  (error "Your data was invalid"))</code></pre>
         </section>
 
         <section>
@@ -43,8 +42,7 @@
           <pre>
 <code class="clojure">(if conditional-expression
   expression-to-evaluate-when-true
-  expression-to-evaluate-when-false)</code>
-</pre>
+  expression-to-evaluate-when-false)</code></pre>
         </section>
 
         <section>
@@ -58,8 +56,7 @@
 (if (&gt; 1 3)
   "1 is greater than 3"
   "1 is not greater than 3")
-;;=&gt; "1 is not greater than 3"</code>
-</pre>
+;;=&gt; "1 is not greater than 3"</code></pre>
         </section>
 
         <section>
@@ -86,8 +83,7 @@
 (if (get {:a 1} :b)
   "expressions which evaluate to nil are considered true"
   "expressions which evaluate to nil are not considered true")
-;;=&gt; "expressions which evaluate to nil are not considered true"</code>
-</pre>
+;;=&gt; "expressions which evaluate to nil are not considered true"</code></pre>
         </section>
 
         <section>
@@ -104,8 +100,7 @@
 ;;=&gt; "Margaret Atwood"
 
 (format-name {:first "Ursula" :last "Le Guin" :middle "K."})
-;;=&gt; "Ursula K. Le Guin"</code>
-</pre>
+;;=&gt; "Ursula K. Le Guin"</code></pre>
         </section>
 
         <section>
@@ -218,8 +213,7 @@
         smallest (reduce min numbers)]
     (- largest smallest)))
 
-(spread [10 7 3 -3 8]) ;=&gt; 13</code>
-</pre>
+(spread [10 7 3 -3 8]) ;=&gt; 13</code></pre>
         </section>
 
         <section>
@@ -249,8 +243,7 @@
 (ordinal 4)  ;=&gt; "4th"
 (ordinal 5)  ;=&gt; "5th"
 (ordinal 21) ;=&gt; "21st"
-(ordinal 22) ;=&gt; "22nd"</code>
-</pre>
+(ordinal 22) ;=&gt; "22nd"</code></pre>
 
           <p>You will need the <code>rem</code> function, which
           takes 2 integers and returns the remainder from dividing
@@ -270,8 +263,7 @@
 (ordinal 11) ;=&gt; "11th"
 (ordinal 12) ;=&gt; "12th"
 (ordinal 13) ;=&gt; "13th"
-(ordinal 14) ;=&gt; "14th"</code>
-</pre>
+(ordinal 14) ;=&gt; "14th"</code></pre>
 
           <p>Part three: rewrite the nested if statements using the
           <code>cond</code> function.</p>

--- a/slides/module8.html
+++ b/slides/module8.html
@@ -30,8 +30,7 @@
 
           <p>Type the following in your terminal:</p>
           <pre>
-<code class="bash">lein new clojurebridge global-growth </code>
-</pre>
+<code class="bash">lein new clojurebridge global-growth </code></pre>
         </section>
 
         <section>
@@ -95,8 +94,7 @@
           <p>Go to the command line and enter:</p>
           <pre>
 <code class="bash">cd global-growth
-lein run</code>
-</pre>
+lein run</code></pre>
         </section>
       </section>
 
@@ -140,8 +138,7 @@ lein run</code>
   (println
    (quotify (str "A man who carries a cat by the tail learns "
                  "something he can learn in no other way.")
-            "Mark Twain")))</code>
-</pre>
+            "Mark Twain")))</code></pre>
         </section>
 
         <section>
@@ -152,8 +149,7 @@ lein run</code>
           sections.</p>
           <pre>
 <code class="clojure">;; in src/global_growth/core.clj
-(ns global-growth.core)</code>
-</pre>
+(ns global-growth.core)</code></pre>
         </section>
 
         <section>
@@ -167,8 +163,7 @@ lein run</code>
           <pre>
 <code class="clojure">:dependencies [[org.clojure/clojure "1.5.1"]
                [clj-http "0.9.0"]
-               [cheshire "5.3.1"]]</code>
-</pre>
+               [cheshire "5.3.1"]]</code></pre>
         </section>
 
         <section>
@@ -177,8 +172,7 @@ lein run</code>
 <code class="clojure">;; in src/global_growth/core.clj
 (ns global-growth.core
   (:require [clj-http.client :as client]
-            [cheshire.core :as json]))</code>
-</pre>
+            [cheshire.core :as json]))</code></pre>
         </section>
       </section>
 
@@ -256,8 +250,7 @@ lein run</code>
       "date": "2010"
     }
   ]
-]</code>
-</pre>
+]</code></pre>
         </section>
 
         <section>
@@ -272,8 +265,7 @@ lein run</code>
 ;;    :request-time 109, :status 200,
 ;;    :headers {"content-length" "10340",
 ;;              "content-type" "application/json;charset=utf-8"},
-;;    :body "[{\"page\":1,\"pages\":6}]"}</code>
-</pre>
+;;    :body "[{\"page\":1,\"pages\":6}]"}</code></pre>
         </section>
 
         <section>
@@ -281,8 +273,7 @@ lein run</code>
           <pre>
 <code class=
 "clojure">(json/parse-string "[{\"page\":1,\"pages\":6}]" true)
-;;=&gt; ({:page 1, :pages 6})</code>
-</pre>
+;;=&gt; ({:page 1, :pages 6})</code></pre>
         </section>
 
         <section>
@@ -302,8 +293,7 @@ lein run</code>
 ;;=&gt; ({:page 1, :pages 6, :per_page "50", :total 252}
 ;;    [{:indicator {:id "EN.POP.DNST", :value "Population density (people per sq. km of land area)"},
 ;;    :country {:id "1A", :value "Arab World"}, :value "25.5287276250072", :decimal "0", :date "2010"},
-;;    ...])</code>
-</pre>
+;;    ...])</code></pre>
         </section>
 
         <section>
@@ -321,8 +311,7 @@ lein run</code>
         metadata (first response)
         results (second response)]
     {:metadata metadata
-     :results results}))</code>
-</pre>
+     :results results}))</code></pre>
         </section>
 
         <section>
@@ -334,8 +323,7 @@ lein run</code>
 ;;    :results [{:indicator {:id "EN.POP.DNST",
 ;;    :value "Population density (people per sq. km of land area)"},
 ;;    :country {:id "1A", :value "Arab World"}, :value "25.5287276250072",
-;;    :decimal "0", :date "2010"} ...]}</code>
-</pre>
+;;    :decimal "0", :date "2010"} ...]}</code></pre>
         </section>
 
         <section>
@@ -352,8 +340,7 @@ lein run</code>
   (get-api "/countries/all/indicators/EN.POP.DNST" {:date 2010}))
 ;;=&gt; [["Arab World" "25.5287276250072"]
 ;;    ["Caribbean small states" "17.0236186241818"]
-;;    ...]</code>
-</pre>
+;;    ...]</code></pre>
         </section>
 
         <section>
@@ -378,8 +365,7 @@ lein run</code>
     (for [[country value] values
           :when (and (not (nil? value))
                      (contains? @countries country))]
-      [country (read-string value)])))</code>
-</pre>
+      [country (read-string value)])))</code></pre>
         </section>
 
         <section>
@@ -387,8 +373,7 @@ lein run</code>
           population density</h3>
           <pre>
 <code class=
-"clojure">(get-indicator-values "EN.POP.DNST" 2010)</code>
-</pre>
+"clojure">(get-indicator-values "EN.POP.DNST" 2010)</code></pre>
 
           <p>What do you get?</p>
         </section>
@@ -422,8 +407,7 @@ lein run</code>
           executes its body and returns nothing.</p>
           <pre>
 <code class="clojure">(doseq [name ["Akeelah" "Bhamini" "Cierra"]]
-  (println name))</code>
-</pre>
+  (println name))</code></pre>
         </section>
 
         <section>

--- a/slides/module9.html
+++ b/slides/module9.html
@@ -47,8 +47,7 @@
 <code class="clojure">(defn app
   [request]
   {:status 200
-   :body "Hello world!"})</code>
-</pre>
+   :body "Hello world!"})</code></pre>
         </section>
 
         <section>
@@ -90,8 +89,7 @@
             [compojure.handler :refer [site]]
             [hiccup.core :as hiccup]
             [hiccup.page :as page]
-            [hiccup.form :as form]))</code>
-</pre>
+            [hiccup.form :as form]))</code></pre>
         </section>
 
         <section>
@@ -108,8 +106,7 @@
 <code class="clojure">(defroutes main-routes
   (GET "/" [] (main-page))
   (GET "/indicators" [indicator1 indicator2 year]
-       (view-indicators indicator1 indicator2 year)))</code>
-</pre>
+       (view-indicators indicator1 indicator2 year)))</code></pre>
         </section>
 
         <section>
@@ -119,8 +116,7 @@
               [:h1 "Hello world!"]
               [:h2 "I am an awesome subheader"]])
 ;;=&gt; "&lt;header&gt;&lt;h1&gt;Hello world!&lt;/h1&gt;
-;;    &lt;h2&gt;I am an awesome subheader&lt;/h2&gt;&lt;/header&gt;"</code>
-</pre>
+;;    &lt;h2&gt;I am an awesome subheader&lt;/h2&gt;&lt;/header&gt;"</code></pre>
         </section>
 
         <section>
@@ -137,8 +133,7 @@
                                 "indicator1"
                                 (api/get-indicators))]]
               ;; ...
-              (form/submit-button "Submit"))</code>
-</pre>
+              (form/submit-button "Submit"))</code></pre>
         </section>
 
         <section>
@@ -150,8 +145,7 @@
           <p>Make sure the following is in the project:</p>
           <pre>
 <code class=
-"clojure">:ring {:handler global-growth.web/handler}</code>
-</pre>
+"clojure">:ring {:handler global-growth.web/handler}</code></pre>
         </section>
 
         <section>
@@ -162,8 +156,7 @@
 
 2014-04-02 21:30:06.303:INFO:oejs.Server:jetty-7.6.8.v20121106
 2014-04-02 21:30:06.378:INFO:oejs.AbstractConnector:Started SelectChannelConnector@0.0.0.0:3000
-Started server on port 3000</code>
-</pre>
+Started server on port 3000</code></pre>
 
           <p>Go to http://localhost:3000/.</p>
         </section>


### PR DESCRIPTION
The trailing newlines cause each of the code blocks to have an empty line at the bottom. This breaks the illusion that the code is on a white surface which sits in front of the background and casts a shadow on it:

![glitch](https://cloud.githubusercontent.com/assets/210406/4429979/214a2686-4611-11e4-9d3f-526e01b152ea.png)
