### PR TITLE
clarified "Bye for now!" message after Control + D command

### DIFF
--- a/outline/setup_osx.md
+++ b/outline/setup_osx.md
@@ -149,7 +149,7 @@ This could take a long time, and will download many other pieces of code it reli
 
 ![Testing lein repl](img/os_x/testing-step2.png)
 
-This is starting a REPL, which we will learn about soon. It's a special terminal for Clojure. At the REPL prompt, type `(+ 1 1)` and press Return. Did you get the answer `2` back? You will learn more about that in the course. For now, press the Control button and D button on your keyboard together (abbreviated as Ctrl+D). This should take you out of the Clojure REPL and back to your normal terminal prompt. `sample.app=> Bye for now!`
+This is starting a REPL, which we will learn about soon. It's a special terminal for Clojure. At the REPL prompt, type `(+ 1 1)` and press Return. Did you get the answer `2` back? You will learn more about that in the course. For now, press the Control button and D button on your keyboard together (abbreviated as Ctrl+D). This should take you out of the Clojure REPL and back to your normal terminal prompt. Then, the terminal will show you the following message: `sample.app=> Bye for now!`
 
 Now, start Applications > LightTable. Once it is started, press the Control button and Space Bar together (abbreviated Ctrl+Space). This is how you start giving LightTable a command. Start typing the word "instarepl" and you should see a menu of options, like below. Choose "Instarepl: open a clojure instarepl."
 


### PR DESCRIPTION
At the workshop in SF last weekend, a couple of students skimmed through the paragraph below and thought that they were meant to type `Bye for now!` into the terminal.

Rewrote that sentence, which will hopefully clarify that the line is meant to be read, not written.
