### PR TITLE
add `rest` example

### DIFF
--- a/outline/data_structures.md
+++ b/outline/data_structures.md
@@ -47,6 +47,9 @@ What can you do with vectors? Vectors are easy to add more items to, delete item
 
 (first [5 10 15])
 ;=> 5
+
+(rest [5 10 15])
+;=> (10 15)
 ```
 
 Let's look at these functions together. First, you see a function called `vector?`. You can probably guess what that does: it tells us whether the argument is a vector. Notice that it has a question mark at the end of it. We often call functions like these _predicate functions_, and they answer true-or-false questions about the data we give them.


### PR DESCRIPTION
In the step immediately following this in the outline, we refer to `rest` as something that was previously shown, however its not actually referred to before that point. This minor edit just adds a `rest` example. 

I'm unsure if this was an oversight or a deliberate choice, but it stuck out to me.
