### PR TITLE
Remove example that references BigInts

### DIFF
--- a/outline/intro.md
+++ b/outline/intro.md
@@ -139,7 +139,6 @@ I used integers with all of the above, but they can use floats or ratios just fi
 ```clj
 (+ 4/3 7/8)   ;=> 53/24
 (- 9 4.2 1/2) ;=> 4.3
-(* 8 1/4)     ;=> 2   ;; this produces 2N which means 2 is a BigInt. 
 (/ 27/2 1.5)  ;=> 9.0
 ```
 


### PR DESCRIPTION
We don't use BigInts anywhere else in the curriculum, so out this example goes!

Fixes https://github.com/ClojureBridge/curriculum/issues/130.