### PR TITLE
slides: avoid "//" and ";;" on infix versus prefix slide

### DIFF
--- a/slides/module1.html
+++ b/slides/module1.html
@@ -134,17 +134,17 @@
           <h3 class="slide-title slide">Infix vs. prefix
           notation</h3>
 
-          <pre><code class="language-javascript">// infix
-1 + 2 * 3 / 4 - 5</code></pre>
+          <p style="text-align:left">Infix:</p>
+          <pre><code class="language-javascript">1 + 2 * 3 / 4 - 5</code></pre>
 
-          <pre><code class="language-clojure">;; prefix
-(- (+ 1 (/ (* 2 3) 4)) 5)</code></pre>
+          <p style="text-align:left">Prefix:</p>
+          <pre><code class="language-clojure">(- (+ 1 (/ (* 2 3) 4)) 5)</code></pre>
 
-          <pre><code class="language-javascript">// infix
-1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9</code></pre>
+          <p style="text-align:left">Infix:</p>
+          <pre><code class="language-javascript">1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9</code></pre>
 
-          <pre><code class="language-clojure">;; prefix
-(+ 1 2 3 4 5 6 7 8 9)</code></pre>
+          <p style="text-align:left">Prefix:</p>
+          <pre><code class="language-clojure">(+ 1 2 3 4 5 6 7 8 9)</code></pre>
         </section>
 
         <section>


### PR DESCRIPTION
Closes #129

@kpfell rightly pointed out that the different line-commenting syntax of JavaScript and Clojure is a distraction.

__Before:__

> ```javascript
> // infix
> 1 + 2 * 3 / 4 - 5
> ```
>
> ```clojure
> ;; prefix
> (- (+ 1 (/ (* 2 3) 4)) 5)
> ```
>
> ```javascript
> // infix
> 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9
> ```
>
> ```clojure
> ;; prefix
> (+ 1 2 3 4 5 6 7 8 9)
> ```

__After:__

> Infix:
>
> ```javascript
> 1 + 2 * 3 / 4 - 5
> ```
>
> Prefix:
>
> ```clojure
> (- (+ 1 (/ (* 2 3) 4)) 5)
> ```
>
> Infix:
>
> ```javascript
> 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9
> ```
>
> Prefix:
>
> ```clojure
> (+ 1 2 3 4 5 6 7 8 9)
> ```
