### PR TITLE
Add git troubleshooting for Windows

### DIFF
--- a/outline/setup_win7.md
+++ b/outline/setup_win7.md
@@ -64,6 +64,26 @@ Inside the Light Table directory, there is an application called Light Table. Ri
 See if you already have Git installed at the command prompt with the command `git --version`.
 If not, download it from the [git-scm.com Windows download page](http://git-scm.com/download/win) and run the executable to install.
 
+After installation, try the `git --version` command in a new command prompt window. If you see a version number, git
+was installed correctly.
+
+If you see a message that says, `'git' is not recognized as an internal or external command`,
+try these steps to update your PATH variable properly:
+* Right-click "My Computer" and select "Properties".
+* Click the "Advanced Tab" and then the "Environment Variables" button.
+* Highlight the PATH entry and click "Edit".
+* Scroll to the end of this value and check for a file path at the end that includes "...\Git...".
+* If that path existed:
+  * Click "Okay" until the "My Computer" dialog box is closed.
+  * Open a new command prompt window and try `git --version` again. If that does not succeed, restart your computer and
+    try again.
+* If that path did not exist:
+  * If you did not change the install location of git during installation, add ";C:\Program Files (x86)\Git\cmd" to the
+    end of the line. Make sure you add the semi-colon between file paths and the line includes no spaces between paths.
+  * Click "Okay" until the "My Computer" dialog box is closed.
+  * Open a new command prompt window and try `git --version` again. If that does not succeed, restart your computer and
+    try again.
+
 If you've used Git before then you should already have user.name and user.email configured.
 Otherwise, type this in the command prompt:
 

--- a/outline/setup_win8.md
+++ b/outline/setup_win8.md
@@ -64,6 +64,26 @@ Inside the Light Table directory, there is an application called Light Table. Ri
 See if you already have Git installed at the command prompt with the command `git --version`.
 If not, download it from the [git-scm.com Windows download page](http://git-scm.com/download/win) and run the executable to install.
 
+After installation, try the `git --version` command in a new command prompt window. If you see a version number, git
+was installed correctly.
+
+If you see a message that says, `'git' is not recognized as an internal or external command`,
+try these steps to update your PATH variable properly:
+* Right-click "My Computer" and select "Properties".
+* Click the "Advanced Tab" and then the "Environment Variables" button.
+* Highlight the PATH entry and click "Edit".
+* Scroll to the end of this value and check for a file path at the end that includes "...\Git...".
+* If that path existed:
+  * Click "Okay" until the "My Computer" dialog box is closed.
+  * Open a new command prompt window and try `git --version` again. If that does not succeed, restart your computer and
+    try again.
+* If that path did not exist:
+  * If you did not change the install location of git during installation, add ";C:\Program Files (x86)\Git\cmd" to the
+    end of the line. Make sure you add the semi-colon between file paths and the line includes no spaces between paths.
+  * Click "Okay" until the "My Computer" dialog box is closed.
+  * Open a new command prompt window and try `git --version` again. If that does not succeed, restart your computer and
+    try again.
+
 If you've used Git before then you should already have user.name and user.email configured.
 Otherwise, type this in the command prompt:
 


### PR DESCRIPTION
Sometimes when installing git on Windows, the PATH variable doesn't
update properly from the install process. Add instructions on manually
editing the PATH variable and restarting to make the change come into
effect.