### PR TITLE
Document opening files/folders in LT from the command line

### DIFF
--- a/outline/setup_osx.md
+++ b/outline/setup_osx.md
@@ -101,7 +101,7 @@ prompt. Click "Open".
 
 Run the following commands to create a "shortcut command" called `light-table`:
 
-    echo "export light-table='open -a /Applications/LightTable/LightTable.app' >> ~/.bash_profile
+    echo "export light-table='open -a /Applications/LightTable/LightTable.app'" >> ~/.bash_profile
     source ~/.bash_profile
 
 You can now open files and folders in LightTable from the command line by entering `light-table path/to/the/file/you/want/to/open.clj`.

--- a/outline/setup_osx.md
+++ b/outline/setup_osx.md
@@ -97,6 +97,14 @@ prompt. Click "Open".
 
 <img alt="Light Table first-run dialog" src="img/os_x/light-table-first-run-dialog@2x.png" width="595" height="290">
 
+### Opening files in LightTable from the command line *(optional)*
+
+Run the following commands to create a "shortcut command" called `light-table`:
+
+    echo "export light-table='open -a /Applications/LightTable/LightTable.app' >> ~/.bash_profile
+    source ~/.bash_profile
+
+You can now open files and folders in LightTable from the command line by entering `light-table path/to/the/file/you/want/to/open.clj`.
 
 ## Testing your setup
 
@@ -108,7 +116,7 @@ Go to your terminal and run the following command:
 git clone https://github.com/ClojureBridge/welcometoclojurebridge
 ```
 
-This will clone a sample Clojure application. 
+This will clone a sample Clojure application.
 
 ![Testing git clone](img/os_x/testing-step1.png)
 
@@ -138,7 +146,7 @@ At the bottom left of the screen, you will see a cube moving and some text about
 
 ![Testing LightTable - running in the instarepl](img/os_x/testing-step4.png)
 
-If that worked, great! 
+If that worked, great!
 
 Now we will open and run the sample Clojure app in LightTable. In LightTable, click on the menu "File" then choose "Open Folder." Find the directory you created earlier, `welcometoclojurebridge` and click "Upload." In the workspace menu on the left, click on welcometoclojurebridge - src - welcometoclojurebridge - core.clj. Double-click the core.clj file to open it. This is a Clojure program. Click on the file contents and press the following key combination:
 

--- a/outline/setup_ubuntu.md
+++ b/outline/setup_ubuntu.md
@@ -22,7 +22,7 @@ For the rest of this setup, I will tell you to run commands in your terminal. Wh
 
 ## Making sure Java is installed
 
-Run `java -version` in your terminal. If you do not have Java installed, Ubuntu will prompt you to install it. It should look something like this: 
+Run `java -version` in your terminal. If you do not have Java installed, Ubuntu will prompt you to install it. It should look something like this:
 
 ![no java](img/ubuntu/no_java.png)
 
@@ -56,19 +56,19 @@ After you run the above commands, run the `lein version` command. It should take
 
 ## Installing Light Table
 
-You will need to know whether you are running the 32-bit or 64-bit version of Ubuntu. To find out, click Dash Home and type Details. You should see a window like this: 
+You will need to know whether you are running the 32-bit or 64-bit version of Ubuntu. To find out, click Dash Home and type Details. You should see a window like this:
 
-![Ubuntu Version](img/ubuntu/ubuntu-version.png) 
+![Ubuntu Version](img/ubuntu/ubuntu-version.png)
 
 Alternatively, open your terminal and type `uname -m` if the output says "x86_64" you have a 64-bit OS, if it says "i686" you have a 32-bit OS.
 
 Go to the [Light Table site](http://www.lighttable.com/). On the page there, you should see a set of buttons that have download links for Light Table.
-Depending on your architecture, click the "Linux64" or "Linux32" button and select the "Save file". 
+Depending on your architecture, click the "Linux64" or "Linux32" button and select the "Save file".
 
 ![Light Table downloads](img/light-table-download.png)
 ![Light Table downloads Ubuntu](img/ubuntu/light-table-download.png)
 
-Open up your terminal and cd to the directory where your downloads go `cd ~/Downloads`. 
+Open up your terminal and cd to the directory where your downloads go `cd ~/Downloads`.
 Check to see that your file is there. `ls`
 Extract the compressed file `tar -xzf LightTableLinux64.tar.gz`
 Check to see that there is now a directory called LightTable `ls`
@@ -77,12 +77,15 @@ Set your path so you can launch LightTable from the command line `export PATH=$P
 Launch LightTable `LightTable`
 
 If you want, you can create a launcher for LightTable. `sudo gnome-desktop-item-edit /usr/share/applications/ --create-new`
-You should see a window like this: 
+You should see a window like this:
 
 ![Create Icon](img/ubuntu/create_icon.png)
 
 Name the launcher LightTable. Type the path to the command `/usr/local/bin/LightTable/LightTable`. Click the icon. The LightTable icon can be found at `/usr/local/bin/LightTable/core/img/lticon.png`.
 
+### Opening files in LightTable from the command line *(optional)*
+
+If you'd prefer, you can open files/folders in LightTable from the command line by typing `light-table /path/to/the/file/you/want/to/open.clj`.
 
 ## Installing Git
 
@@ -150,7 +153,7 @@ At the bottom of the screen, you will see a cube moving and some text about conn
 
 ![Testing Light Table - running in the instarepl](img/ubuntu/testing-step4.png)
 
-If that worked, great! Close Light Table. 
+If that worked, great! Close Light Table.
 
 Finally, let's make sure the application you downloaded will run properly.  To test this, you will use Leiningen to run the application on your computer.  As this is a (very simple) web application, you should be able to use a web browser to see it runnning in all its humble glory.  Let's start with
 


### PR DESCRIPTION
See issue #87. 

This documents, in the setup guides for Mac OS X and Ubuntu, how to open files/folders in LightTable from the command line. This is fairly advanced for beginning programmers, so I've noted that this is an optional step. 