### PR TITLE
Adds troubleshooting section to setup_osx.md and setup_win7.md

### DIFF
--- a/outline/setup_osx.md
+++ b/outline/setup_osx.md
@@ -8,6 +8,9 @@ OS X Setup
 * Get Leiningen installed
 * Get LightTable installed
 * Test installation
+* Troubleshooting
+    - OS X 10.6.8
+    - Yosemite
 
 ## Starting a terminal
 
@@ -147,3 +150,23 @@ Now we will open and run the sample Clojure app in LightTable. In LightTable, cl
 You should see a fun welcome message.
 
 Congratulations! You have opened and run your first Clojure app, and your install and setup are complete!
+
+
+## Troubleshooting
+
+### OS X 10.6.8
+
+Light Table actually does work on OS X 10.6.8. It thinks it does not. To convince it otherwise, do this:
+
+  1. Use a text editor to open /Applications/LightTable.app/Contents/Info.plist
+  2. Search for the key LSMinimumSystemVersion
+  3. Remove that key from the file. Delete this entire text: LSMinimumSystemVersion 10.7.5
+  4. Save the file, and you should be able to start Light Table.
+
+### Yosemite
+
+Yosemite was released after Light Table development was stalled.
+Because of this historical reason, students may encounter troubles to start or use Light Table on Yosemite.
+In such a case, [Nightcode](https://sekao.net/nightcode/) is another option.
+See the instruction,
+[Getting Started with Clojure using Nightcode](https://github.com/ClojureBridge/getting-started/blob/master/nightcode.md).

--- a/outline/setup_win7.md
+++ b/outline/setup_win7.md
@@ -7,6 +7,7 @@ Windows 7 Setup
 * Get Light Table installed
 * Get Git installed
 * Test installation
+* Troubleshooting
 
 ## Starting a command prompt
 
@@ -142,4 +143,20 @@ This is what your browser should look like if everything has been successful.
 Congratulations! You have actually made a very simple Clojure app, and your computer is all set up to make more.
 
 
+## Troubleshooting
 
+  Students with Windows 7 may get the error below when they run `lein repl` for the first time.
+
+  ```
+  Address family not supported by protocol family: connect
+  ```
+
+  If the error message is this, look at <http://stackoverflow.com/a/21383865>.
+
+
+  This error happens because `lein` command couldn't download necessary stuffs
+  because a program called Relevant Knowledge, some sort of spyware, blocks the traffic.
+  To solve this problem, uninstall Relevant Knowledge.
+  This requires users' (owner's or administrator's) password.
+  Sometimes, attendees haven't heard of such permission stuff.
+  Be ready for that.


### PR DESCRIPTION
This pull request adds troubleshooting section to setup_osx.md and setup_win7.md.

For osx, the section is based on https://github.com/ClojureBridge/curriculum/issues/78. For windows 7, it's from https://github.com/ClojureBridge/curriculum/issues/75.
Also, the discussion, https://github.com/ClojureBridge/curriculum/issues/98, is related.

I believe these troubleshooting should be the same setup doc since people can easily recognize the solution.