### PR TITLE
typo fix: export should be alias

### DIFF
--- a/backup/outline/setup_osx.md
+++ b/backup/outline/setup_osx.md
@@ -104,7 +104,7 @@ prompt. Click "Open".
 
 Run the following commands to create a "shortcut command" called `light-table`:
 
-    echo "export light-table='open -a /Applications/LightTable/LightTable.app'" >> ~/.bash_profile
+    echo "alias light-table='open -a /Applications/LightTable/LightTable.app'" >> ~/.bash_profile
     source ~/.bash_profile
 
 You can now open files and folders in LightTable from the command line by entering `light-table path/to/the/file/you/want/to/open.clj`.


### PR DESCRIPTION
This is re: Issue #87 -- I submitted a PR about a month ago adding OSX and Linux instructions for opening files from the command line in Light Table. I just realized the OSX instructions are slightly incorrect... for creating a bash alias, `export` should really be `alias`. This PR fixes that! :balloon: :tada: :confetti_ball: 