### PR TITLE
Adds necessary comma to merge result

### DIFF
--- a/outline/data_structures.md
+++ b/outline/data_structures.md
@@ -233,7 +233,7 @@ be confusing.
 ;=> {:first "Sally"}
 
 (merge {:first "Sally"} {:last "Brown"})
-;=> {:first "Sally" :last "Brown"}
+;=> {:first "Sally", :last "Brown"}
 ```
 </section>
 


### PR DESCRIPTION
It confused me that the `assoc` and `merge` functions would result in seemingly-different looking results. After trying this in the REPL, I see that `merge` is just missing a comma between the two key value pairs.
