### PR TITLE
Update pdf-cheatsheet name to match new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Choices of Capstone App - Part. 2
 
 Supporting Materials
 --------------------
-* [Student Cheatsheet](outline/cheatsheet.md) | [PDF](ClojureBridgeCheatsheet-v1.pdf)
+* [Student Cheatsheet](outline/cheatsheet.md) | [PDF](ClojurebridgeCheatsheet-v2.pdf)
 * [Old Curriculum](http://clojurebridge.github.io/curriculum/index.v0.html)
 
 Repositories

--- a/TEACHING.md
+++ b/TEACHING.md
@@ -48,7 +48,7 @@ Saturday: Workshop -  [curriculum](README.md#curriculum).
 
 Preparation
 -----------
-Print the ([markdown](outline/cheatsheet.md) or [pdf](ClojureBridgeCheatsheet-v1.pdf)) and hand it out to students at the beginning of the day on Saturday.
+Print the ([markdown](outline/cheatsheet.md) or [pdf](ClojurebridgeCheatsheet-v2.pdf)) and hand it out to students at the beginning of the day on Saturday.
 
 Room Setup
 ----------
@@ -110,7 +110,7 @@ TODO: add tips under each heading.
 
 Supporting Materials
 --------------------
-* [Student cheatsheet](outline/cheatsheet.md) | [PDF](ClojureBridgeCheatsheet-v1.pdf)
+* [Student cheatsheet](outline/cheatsheet.md) | [PDF](ClojurebridgeCheatsheet-v2.pdf)
 * [Slides](http://clojurebridge.github.io/curriculum)
 
 

--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,7 @@ exclude:
 - Gemfile.lock
 - CONTRIBUTING.md
 - EDITING-CURRICULUM.md
-- ClojureBridgeCheatsheet-v1.pdf
+- ClojurebridgeCheatsheet-v2.pdf
 - TEACHING.md
 - background-reading.md
 - tmp


### PR DESCRIPTION
This commit fixes broken links that point to older version of pdf-cheatsheet.
