### PR TITLE
Fix jQuery blocked mixed content error

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,7 +14,7 @@
           href="{{ "/assets/prism.css" | prepend: site.baseurl }}">
     <link rel="stylesheet"
           href="{{ "/assets/clojurebridge.css" | prepend: site.baseurl }}">
-    <script type="text/javascript" src="http://code.jquery.com/jquery-1.6.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-1.6.min.js"></script>
     <link rel="icon" type="image/png" href="{{ site.baseurl }}/img/favicon.png">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 </head>


### PR DESCRIPTION
My mistake, I was using the add-on `https everywhere` so I had faced the issue.